### PR TITLE
Callback to get time to next job run can now cancel the job running

### DIFF
--- a/scheduler/package-lock.json
+++ b/scheduler/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@data-heaving/scheduler",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@data-heaving/scheduler",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@data-heaving/common": "0.12.0"

--- a/scheduler/package.json
+++ b/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-heaving/scheduler",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",


### PR DESCRIPTION
Done:
- Callback to get time to next job run can now cancel the job running
- It is also the only way to cancel running job